### PR TITLE
Remove WASM

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,9 +83,11 @@ RUN umask 0002 \
 RUN umask 0002 \
 && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
 && cargo binstall --secure -y \
-    cargo-cyclonedx \        
+    cargo-cyclonedx \
     cargo-expand \
+    cargo-machete \
     cargo-nextest \
+    cargo-udeps \
     cargo-xwin \
     grcov \
     mdbook \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,8 +90,7 @@ RUN umask 0002 \
     cargo-xwin \
     grcov \
     mdbook \
-    miniserve \
-    wasm-pack
+    miniserve
 
 RUN umask 0002 \
 && cat <<EOF >> ${CARGO_HOME}/config.toml
@@ -113,10 +112,6 @@ RUN dnf install -y \
     libinput \
     wayland-devel \
     xorg-x11-server-Xwayland
-
-# Chromium for headless wasm testing
-RUN dnf install -y \
-    chromium
 
 # ---
 # Final setup steps

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,7 +71,6 @@ USER root:rust
 RUN umask 0002 \
 && rustup-init -v -y \
 && rustup target add \
-    wasm32-unknown-unknown \
     x86_64-pc-windows-msvc \
 && rustup component add \
     clippy \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,13 @@ jobs:
         ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Skip windows unless `[CI-win]` is in the commit message (or this is a PR)
-        if: ${{ runner.os == 'Windows' }} && !contains(github.event.head_commit.message, '[CI-win]')
-        run: exit 1
       - uses: actions/checkout@v4
       - uses: swatinem/rust-cache@v2
         if: ${{ runner.os != 'Windows' }}
         with:
           shared-key: "helixflow"
       - name: Cache cargo registry and build
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ runner.os == 'Windows' && (github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[CI-win]')) }}
         uses: actions/cache@v4
         with:
           path: |
@@ -44,6 +41,7 @@ jobs:
         with:
           tool: cargo-nextest
       - name: "Test"
+        if: ${{ runner.os != 'Windows' || (github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[CI-win]')) }}
         run: cargo nextest run
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,13 @@ jobs:
       matrix:
         os: [
           ubuntu-latest, 
-          # windows-latest,
+          windows-latest,
         ]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Skip windows unless `[CI-win]` is in the commit message (or this is a PR)
+        if: ${{ runner.os == 'Windows' }} && !contains(github.event.head_commit.message, '[CI-win]')
+        run: exit 1
       - uses: actions/checkout@v4
       - uses: swatinem/rust-cache@v2
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,26 +42,7 @@ jobs:
           tool: cargo-nextest
       - name: "Test"
         run: cargo nextest run
-  test-wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: swatinem/rust-cache@v2
-        with:
-          shared-key: "helixflow"
-      - name: "Set up Rust"
-        run: |
-          rustup show
-          rustup target add wasm32-unknown-unknown
-      - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
-      # Need to run individually for each crate. See: https://github.com/rustwasm/wasm-pack/issues/642
-      - name: "Test helixflow-core"
-        run: |
-          cd helixflow-core
-          wasm-pack test --headless --chrome
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +56,7 @@ jobs:
           rustup component add clippy
       - name: "Lint"
         run: cargo clippy
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
 on:
+  push:
+    branches:
+      main
   pull_request:
   workflow_dispatch:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,10 @@ thiserror = "2.0.12"
 tokio = { version = "1.44.2" }
 uuid = { version = "1.16.0", features = ["v7", "js"] }
 
-# wasm
-console_error_panic_hook = { version = "0.1.7" }
-console_log = { version = "1.0.0" }
-getrandom = { version = "0.3.3", features = ["wasm_js"] }
-wasm-bindgen = { version = "0.2" }
-
 # dev-only dependencies
 assert_unordered = "0.3.5"
 i-slint-backend-testing = { git = "https://github.com/slint-ui/slint" }
 rstest = "0.25.0"
-wasm-bindgen-test = "0.3.50"
 
 # build dependencies
 slint-build = { git = "https://github.com/slint-ui/slint" }

--- a/backends/helixflow-surreal/.cargo/config.toml
+++ b/backends/helixflow-surreal/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/backends/helixflow-surreal/Cargo.toml
+++ b/backends/helixflow-surreal/Cargo.toml
@@ -11,12 +11,5 @@ serde = { workspace = true, features = ["derive"] }
 surrealdb.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 
-wasm-bindgen-test.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-
 [dev-dependencies]
 assert_unordered.workspace = true

--- a/backends/helixflow-surreal/src/lib.rs
+++ b/backends/helixflow-surreal/src/lib.rs
@@ -265,8 +265,8 @@ impl SurrealDb<Db> {
     }
 }
 
-/// Can't run blocking on wasm as `runtime::Builder::enable_all()` needs `time` AND
-/// `block_on()` will not run either, as rt cannot be idle.
+// Can't run blocking on wasm as `runtime::Builder::enable_all()` needs `time` AND
+// `block_on()` will not run either, as rt cannot be idle.
 #[cfg(test)]
 #[coverage(off)]
 mod tests {

--- a/backends/helixflow-surreal/src/lib.rs
+++ b/backends/helixflow-surreal/src/lib.rs
@@ -265,18 +265,14 @@ impl SurrealDb<Db> {
     }
 }
 
-
 /// Can't run blocking on wasm as `runtime::Builder::enable_all()` needs `time` AND
 /// `block_on()` will not run either, as rt cannot be idle.
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
-
     use std::assert_matches::assert_matches;
 
     use super::*;
-
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]
     fn test_new_task() {

--- a/helixflow-core/Cargo.toml
+++ b/helixflow-core/Cargo.toml
@@ -8,6 +8,3 @@ anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 uuid = { workspace = true, features = ["serde"] }
-
-[dev-dependencies]
-wasm-bindgen-test.workspace = true

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -386,16 +386,11 @@ impl Relate<Contains<TaskList, Task>> for TestBackend {
     }
 }
 
-
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
-    use std::assert_matches::assert_matches;
-    use wasm_bindgen_test::*;
-
     use super::*;
-
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn try_contains_oks() -> HelixFlowResult<()> {
@@ -450,7 +445,7 @@ mod tests {
         )
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_new_task() {
         let new_task = Task::new("Test Task", None);
         assert_eq!(new_task.name, "Test Task");
@@ -459,7 +454,7 @@ mod tests {
         assert_eq!(new_task.id.get_version(), Some(uuid::Version::SortRand));
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_new_task_blank() {
         let new_task = Task::new("", None);
         assert_eq!(new_task.name, "");
@@ -468,14 +463,14 @@ mod tests {
         assert_eq!(new_task.id.get_version(), Some(uuid::Version::SortRand));
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_create_task() {
         let new_task = Task::new("Test Task 1", None);
         let backend = TestBackend;
         new_task.create(&backend).unwrap();
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_failed_to_create_task() {
         let new_task = Task::new("FAIL", None);
         let backend = TestBackend;
@@ -483,7 +478,7 @@ mod tests {
         assert_matches!(err, HelixFlowError::BackendError(_))
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_mismatched_task_created() {
         let new_task = Task::new("MISMATCH", None);
         let backend = TestBackend;
@@ -497,7 +492,7 @@ mod tests {
         )
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_get_task() {
         let backend = TestBackend;
         let id = uuid!("0196b4c9-8447-7959-ae1f-72c7c8a3dd36");
@@ -509,10 +504,10 @@ mod tests {
                 id,
                 description: None
             }
-        )
+        );
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
+    #[test]
     fn test_get_invalid_task() {
         let backend = TestBackend;
         let id = uuid!("0196b4c9-8447-78db-ae8a-be68a8095aa2");

--- a/helixflow/.cargo/config.toml
+++ b/helixflow/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/helixflow/Cargo.toml
+++ b/helixflow/Cargo.toml
@@ -14,6 +14,5 @@ log.workspace = true
 slint.workspace = true
 
 [dev-dependencies]
-futures = "0.3.31"
 i-slint-backend-testing.workspace = true
 uuid.workspace = true

--- a/helixflow/Cargo.toml
+++ b/helixflow/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 helixflow-core.workspace = true

--- a/helixflow/Cargo.toml
+++ b/helixflow/Cargo.toml
@@ -17,9 +17,3 @@ slint.workspace = true
 futures = "0.3.31"
 i-slint-backend-testing.workspace = true
 uuid.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook.workspace = true
-console_log.workspace = true
-getrandom.workspace = true
-wasm-bindgen.workspace = true

--- a/helixflow/index.html
+++ b/helixflow/index.html
@@ -1,11 +1,6 @@
 <html>
     <body>
-        <!-- canvas required by the Slint runtime -->
-        <canvas id="canvas"></canvas>
-        <script type="module">
-            // import the generated file.
-            import init from "./pkg/helixflow.js";
-            init();
-        </script>
+        <!-- This file previously loaded the WASM build for HelixFlow. WASM support is currently disabled. -->
+        <!-- To re-enable, restore the previous HTML and WASM loader. -->
     </body>
 </html>

--- a/helixflow/src/lib.rs
+++ b/helixflow/src/lib.rs
@@ -38,13 +38,3 @@ pub fn run_helixflow() {
     slint::run_event_loop().unwrap();
     helixflow.hide().unwrap();
 }
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen::prelude::wasm_bindgen(start)]
-pub fn wasm_start() {
-    console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).expect("error initializing log");
-    debug!("Running helixflow in wasm");
-    // panic!("So long and thanks for all the fish")
-    run_helixflow();
-}


### PR DESCRIPTION
## Summary by Sourcery

Remove WASM support across the project by stripping out WASM entry points, dependencies, and test harness configuration, and update development tooling accordingly.

Build:
- Remove WASM-specific dependencies from Cargo.toml across all crates
- Add cargo-machete and cargo-udeps to the devcontainer Dockerfile

Documentation:
- Update index.html to remove the WASM loader script and note that WASM support is disabled

Tests:
- Convert wasm_bindgen_test annotations and imports to standard #[test] functions

Chores:
- Remove the wasm_start entry point and related WASM code from helixflow/src/lib.rs