### PR TITLE
Fix dependabot not updating deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase
   - package-ecosystem: "docker"
     directory: "/.devcontainer/"
     schedule:


### PR DESCRIPTION
## Summary by Sourcery

Enable Dependabot to properly update npm dependencies by specifying an explicit versioning strategy

Bug Fixes:
- Fix Dependabot not updating npm dependencies by adding the missing versioning strategy

CI:
- Add 'versioning-strategy: increase' for npm updates in .github/dependabot.yml