### PR TITLE
use taiki to install just

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,8 +28,10 @@ jobs:
           rustup show
           rustup component add llvm-tools llvm-tools-preview
 
-      - name: Set up Just
-        uses: extractions/setup-just@v2
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace extractions/setup-just@v2 with taiki-e/install-action@v2 to install Just in the coverage workflow.