### PR TITLE
try `bump_versions` as dependabot `versioning-strategy`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: increase
+    # docs specify `increase` & `increase_if_necessary `but code appears to use this:
+    # https://github.com/dependabot/dependabot-core/blob/1195171bbe99c15b926f75478820c9e22763fd0a/common/lib/dependabot/requirements_update_strategy.rb#L7
+    # https://github.com/dependabot/dependabot-core/blob/1195171bbe99c15b926f75478820c9e22763fd0a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb#L85
+    versioning-strategy: bump_versions 
   - package-ecosystem: "docker"
     directory: "/.devcontainer/"
     schedule:


### PR DESCRIPTION
## Summary by Sourcery

Update Dependabot configuration to use the bump_versions strategy and clarify the choice with inline comments referencing the Dependabot source code

Chores:
- Switch versioning-strategy from "increase" to "bump_versions" in .github/dependabot.yml
- Add comments explaining the discrepancy between documentation and the actual Dependabot code