### PR TITLE
Tidy helixflow-core in preparation for non-task-related items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ uuid = { version = "1.16.0", features = ["v7", "js"] }
 assert_unordered = "0.3.5"
 i-slint-backend-testing = { git = "https://github.com/slint-ui/slint" }
 rstest = "0.25.0"
-rstest_reuse = "0.7.0"
 tempfile = "3.20.0"
 
 # build dependencies

--- a/backends/helixflow-surreal/Cargo.toml
+++ b/backends/helixflow-surreal/Cargo.toml
@@ -14,5 +14,4 @@ tokio = { workspace = true, features = ["rt", "time"] }
 [dev-dependencies]
 assert_unordered.workspace = true
 rstest.workspace = true
-rstest_reuse.workspace = true
 tempfile.workspace = true

--- a/backends/helixflow-surreal/src/lib.rs
+++ b/backends/helixflow-surreal/src/lib.rs
@@ -15,7 +15,10 @@ use surrealdb::{
     sql::{Id, Thing},
 };
 
-use helixflow_core::task::{HelixFlowError, HelixFlowResult, Task, TaskList};
+use helixflow_core::{
+    HelixFlowError, HelixFlowResult,
+    task::{Task, TaskList},
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 /// SurrealDb returns a `Thing` as `id`.

--- a/backends/helixflow-surreal/src/lib.rs
+++ b/backends/helixflow-surreal/src/lib.rs
@@ -317,61 +317,75 @@ mod tests {
     use super::*;
 
     use rstest::*;
-    use rstest_reuse::*;
 
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempPath};
 
-    fn no_file() -> SurrealDb<Db> {
-        SurrealDb::new(None).unwrap()
+    #[derive(Clone, Copy, Debug)]
+    enum BackendKind {
+        Mem,
+        File,
     }
 
-    fn save_to_file() -> SurrealDb<Db> {
-        let tmpfile = NamedTempFile::new().unwrap();
-        let location = tmpfile.path().into();
-        tmpfile.close().unwrap(); // explicity delete the file - we just need a valid, unique PathBuf
-        SurrealDb::new(Some(location)).unwrap()
+    struct Backend {
+        _file_destructor: Option<TempPath>,
+        backend: SurrealDb<Db>,
     }
 
-    #[template]
-    #[rstest]
-    #[case::mem(no_file)]
-    #[case::save(save_to_file)]
-    fn test_backends<F>(#[case] backend: F)
-    where
-        F: FnOnce() -> SurrealDb<Db>,
-    {
-    }
-
-    #[apply(test_backends)]
-    fn test_new_task<F>(#[case] backend: F)
-    where
-        F: FnOnce() -> SurrealDb<Db>,
-    {
-        let new_task = Task::new("Test Task 1", None);
-        let backend = backend();
-        backend.create(&new_task).unwrap(); // Unwrap to check we don't get any errors
-    }
-
-    #[apply(test_backends)]
-    fn test_new_task_written_to_db<F>(#[case] backend: F)
-    where
-        F: FnOnce() -> SurrealDb<Db>,
-    {
-        {
-            let new_task = Task::new("Test Task 2", None);
-            let backend = backend();
-            backend.create(&new_task).unwrap(); // Unwrap to check we don't get any errors
-            let stored_task: Task = backend.get(&new_task.id).unwrap();
-            assert_eq!(stored_task, new_task);
+    impl From<BackendKind> for Backend {
+        fn from(kind: BackendKind) -> Self {
+            match kind {
+                BackendKind::Mem => Backend {
+                    _file_destructor: None,
+                    backend: SurrealDb::new(None).unwrap(),
+                },
+                BackendKind::File => {
+                    let tmpfile = NamedTempFile::new().unwrap();
+                    let location = tmpfile.path().into();
+                    let tmppath = tmpfile.into_temp_path();
+                    std::fs::remove_file(&location).unwrap();
+                    Backend {
+                        _file_destructor: Some(tmppath),
+                        backend: SurrealDb::new(Some(location)).unwrap(),
+                    }
+                }
+            }
         }
     }
 
-    #[apply(test_backends)]
-    fn test_get_not_found<F>(#[case] backend: F)
-    where
-        F: FnOnce() -> SurrealDb<Db>,
-    {
-        let backend = backend();
+    #[rstest]
+    #[case(BackendKind::Mem)]
+    #[case(BackendKind::File)]
+    fn test_new_task(#[case] kind: BackendKind) {
+        let Backend {
+            _file_destructor,
+            backend,
+        } = kind.into();
+        let new_task = Task::new("Test Task 1", None);
+        backend.create(&new_task).unwrap();
+    }
+
+    #[rstest]
+    #[case(BackendKind::Mem)]
+    #[case(BackendKind::File)]
+    fn test_new_task_written_to_db(#[case] kind: BackendKind) {
+        let Backend {
+            _file_destructor,
+            backend,
+        } = kind.into();
+        let new_task = Task::new("Test Task 2", None);
+        backend.create(&new_task).unwrap();
+        let stored_task: Task = backend.get(&new_task.id).unwrap();
+        assert_eq!(stored_task, new_task);
+    }
+
+    #[rstest]
+    #[case(BackendKind::Mem)]
+    #[case(BackendKind::File)]
+    fn test_get_not_found(#[case] kind: BackendKind) {
+        let Backend {
+            _file_destructor,
+            backend,
+        } = kind.into();
         let id = Uuid::now_v7();
         let res: HelixFlowResult<Task> = backend.get(&id);
         let err = res.unwrap_err();

--- a/backends/helixflow-surreal/src/lib.rs
+++ b/backends/helixflow-surreal/src/lib.rs
@@ -98,7 +98,7 @@ struct Link {
     out: Thing,
 }
 
-use helixflow_core::task::{Contains, Relate, Store};
+use helixflow_core::{Relate, Store, task::Contains};
 /// An instance of a SurrealDb ready to use as a `StorageBackend`
 ///
 /// This requires some form of instantiation function, the exact specification of which will depend

--- a/helixflow-core/src/lib.rs
+++ b/helixflow-core/src/lib.rs
@@ -6,4 +6,15 @@
 #![feature(coverage_attribute)]
 #![feature(try_trait_v2)]
 
+use std::any::Any;
+
 pub mod task;
+
+/// Marker trait for our data items
+pub trait HelixFlowItem
+where
+    // required for Mismatch Error (which uses `Box<dyn HelixFlowItem>`)
+    Self: std::fmt::Debug + Send + Sync + 'static + Any,
+{
+    fn as_any(&self) -> &dyn Any;
+}

--- a/helixflow-core/src/lib.rs
+++ b/helixflow-core/src/lib.rs
@@ -100,13 +100,14 @@ where
 ///    type Right = Task;
 /// }
 /// ```
-// TODO: Add derive macro to generate Relationship, Try & FromResidual for valid type pairings
+// TODO: Add derive macro to generate Link, Linkable, Relate, Try & FromResidual for valid type pairings
+// Can't do this in a blanket impl as it requires guarantees for fields `left`and `right`
 pub trait Relationship
 where
     Self: Sized,
 {
-    type Left;
-    type Right;
+    type Left: HelixFlowItem;
+    type Right: HelixFlowItem;
 }
 
 /// `impl Link<REL> for LEFT` gives `Left Rel:(-> link_type -> Right)`

--- a/helixflow-core/src/lib.rs
+++ b/helixflow-core/src/lib.rs
@@ -47,3 +47,87 @@ pub enum HelixFlowError {
 }
 
 pub type HelixFlowResult<T> = std::result::Result<T, HelixFlowError>;
+
+pub trait CRUD
+where
+    Self: Sized,
+{
+    fn create<B: Store<Self>>(&self, backend: &B) -> HelixFlowResult<()>;
+    fn get<B: Store<Self>>(backend: &B, id: &Uuid) -> HelixFlowResult<Self>;
+}
+
+/// Methods to store and retrieve `ITEM` in a backend
+pub trait Store<ITEM> {
+    /// Create a new `ITEM` in the backend.
+    ///
+    /// The returned `ITEM` should be the actual stored record from the backend - to allow
+    /// validation by `CRUD<ITEM>::create()`
+    fn create(&self, item: &ITEM) -> HelixFlowResult<ITEM>;
+
+    /// Get an `ITEM` from the backend
+    fn get(&self, id: &Uuid) -> HelixFlowResult<ITEM>;
+}
+
+impl<ITEM> CRUD for ITEM
+where
+    ITEM: HelixFlowItem + PartialEq + Clone,
+{
+    /// Create this item in a given storage backend.
+    fn create<B: Store<ITEM>>(&self, backend: &B) -> HelixFlowResult<()> {
+        let created_item = backend.create(self)?;
+        if &created_item == self {
+            Ok(())
+        } else {
+            Err(HelixFlowError::Mismatch {
+                expected: Box::new(self.clone()),
+                actual: Box::new(created_item),
+            })
+        }
+    }
+
+    /// Get item from `backend` by `id`
+    fn get<B: Store<ITEM>>(backend: &B, id: &Uuid) -> HelixFlowResult<ITEM> {
+        backend.get(id)
+    }
+}
+
+/// A valid usage of a relationship struct, defining acceptable types for left & right.
+///
+/// E.g. to allow `Contains`to be used for `TaskList -> Contains -> Task`:
+/// ```ignore
+/// impl Relationship for Contains<TaskList, Task> {
+///    type Left = TaskList;
+///    type Right = Task;
+/// }
+/// ```
+// TODO: Add derive macro to generate Relationship, Try & FromResidual for valid type pairings
+pub trait Relationship
+where
+    Self: Sized,
+{
+    type Left;
+    type Right;
+}
+
+/// `impl Link<REL> for LEFT` gives `Left Rel:(-> link_type -> Right)`
+pub trait Link
+where
+    Self: Relationship,
+{
+    fn create_linked_item<B: Relate<Self>>(self, backend: &B) -> HelixFlowResult<()>;
+}
+
+pub trait Linkable<REL: Link> {
+    fn link(&self, right: &REL::Right) -> REL;
+    fn get_linked_items<B: Relate<REL>>(
+        &self,
+        backend: &B,
+    ) -> HelixFlowResult<impl Iterator<Item = REL>>;
+}
+
+/// Methods to relate items in a backend
+pub trait Relate<REL: Link> {
+    /// Create and link the related item
+    fn create_linked_item(&self, link: &REL) -> HelixFlowResult<REL>;
+    fn get_linked_items(&self, left: &REL::Left) -> HelixFlowResult<impl Iterator<Item = REL>>;
+}

--- a/helixflow-core/src/lib.rs
+++ b/helixflow-core/src/lib.rs
@@ -13,6 +13,8 @@ use uuid::Uuid;
 pub mod task;
 
 /// Marker trait for our data items
+// TODO: Derive macro for HelixFlowItem, as we can't have a standard impl of `as_any`
+//       and remain dyn compatible
 pub trait HelixFlowItem
 where
     // required for Mismatch Error (which uses `Box<dyn HelixFlowItem>`)
@@ -100,8 +102,9 @@ where
 ///    type Right = Task;
 /// }
 /// ```
-// TODO: Add derive macro to generate Link, Linkable, Relate, Try & FromResidual for valid type pairings
-// Can't do this in a blanket impl as it requires guarantees for fields `left`and `right`
+// TODO: Add derive macro to generate Link, Linkable, Relate, Try & FromResidual for valid
+//       type pairings. Can't do this in a blanket impl as it requires guarantees for fields
+//       `left` and `right`
 pub trait Relationship
 where
     Self: Sized,

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -75,11 +75,6 @@ impl TaskList {
     }
 }
 
-impl Relationship for Contains<TaskList, Task> {
-    type Left = TaskList;
-    type Right = Task;
-}
-
 #[derive(Debug)]
 pub struct Contains<LEFT, RIGHT> {
     pub left: HelixFlowResult<LEFT>,
@@ -133,6 +128,11 @@ where
             },
         })
     }
+}
+
+impl Relationship for Contains<TaskList, Task> {
+    type Left = TaskList;
+    type Right = Task;
 }
 
 impl Link for Contains<TaskList, Task> {

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -10,7 +10,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use uuid::{Uuid, uuid};
 
-use crate::HelixFlowItem;
+use crate::{HelixFlowError, HelixFlowItem, HelixFlowResult};
 
 impl HelixFlowItem for Task {
     fn as_any(&self) -> &dyn Any {
@@ -150,33 +150,6 @@ where
         })
     }
 }
-
-#[derive(Debug, thiserror::Error)]
-pub enum HelixFlowError {
-    // The #[from] anyhow::Error will convert anything that offers `into anyhow::Error`.
-    #[error("backend error: {0}")]
-    BackendError(#[from] anyhow::Error),
-
-    #[error("created item does not match expectations: expected {expected:?}, got {actual:?}")]
-    Mismatch {
-        expected: Box<dyn HelixFlowItem>,
-        actual: Box<dyn HelixFlowItem>,
-    },
-
-    #[error("task id ({id:?}) is not a valid UUID v7")]
-    InvalidID { id: String },
-
-    #[error("404 No {itemtype} found with id {id}")]
-    NotFound { itemtype: String, id: Uuid },
-
-    #[error("Relationship between {left:?} and {right:?} contains Errors")]
-    RelationshipBetweenErrors {
-        left: Box<HelixFlowResult<Box<dyn HelixFlowItem>>>,
-        right: Box<HelixFlowResult<Box<dyn HelixFlowItem>>>,
-    },
-}
-
-pub type HelixFlowResult<T> = std::result::Result<T, HelixFlowError>;
 
 pub trait CRUD
 where

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -159,8 +159,13 @@ where
     }
 }
 
-impl Linkable<Contains<TaskList, Task>> for TaskList {
-    fn link(&self, task: &Task) -> Contains<TaskList, Task> {
+impl<LEFT, RIGHT> Linkable<Contains<LEFT, RIGHT>> for LEFT
+where
+    Contains<LEFT, RIGHT>: Relationship<Left = LEFT, Right = RIGHT>,
+    LEFT: HelixFlowItem + Clone + PartialEq,
+    RIGHT: HelixFlowItem + Clone + PartialEq,
+{
+    fn link(&self, task: &RIGHT) -> Contains<LEFT, RIGHT> {
         Contains {
             left: Ok(self.clone()),
             sortorder: "a".into(),
@@ -170,9 +175,9 @@ impl Linkable<Contains<TaskList, Task>> for TaskList {
     fn get_linked_items<B>(
         &self,
         backend: &B,
-    ) -> HelixFlowResult<impl Iterator<Item = Contains<TaskList, Task>>>
+    ) -> HelixFlowResult<impl Iterator<Item = Contains<LEFT, RIGHT>>>
     where
-        B: Relate<Contains<TaskList, Task>>,
+        B: Relate<Contains<LEFT, RIGHT>>,
     {
         backend.get_linked_items(self)
     }

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -84,8 +84,7 @@ pub struct Contains<LEFT, RIGHT> {
 
 impl<LEFT, RIGHT> Try for Contains<LEFT, RIGHT>
 where
-    LEFT: HelixFlowItem,
-    RIGHT: HelixFlowItem,
+    Contains<LEFT, RIGHT>: Relationship,
 {
     type Output = Self; // Continue
     type Residual = Self; // Break
@@ -103,8 +102,7 @@ where
 
 impl<LEFT, RIGHT> FromResidual<Contains<LEFT, RIGHT>> for Contains<LEFT, RIGHT>
 where
-    LEFT: HelixFlowItem,
-    RIGHT: HelixFlowItem,
+    Contains<LEFT, RIGHT>: Relationship,
 {
     fn from_residual(_residual: Contains<LEFT, RIGHT>) -> Self {
         unimplemented!("Contains? should only be used in funtions returning a Result")
@@ -113,6 +111,7 @@ where
 
 impl<LEFT, RIGHT> FromResidual<Contains<LEFT, RIGHT>> for HelixFlowResult<()>
 where
+    Contains<LEFT, RIGHT>: Relationship,
     LEFT: HelixFlowItem,
     RIGHT: HelixFlowItem,
 {

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -82,6 +82,11 @@ pub struct Contains<LEFT, RIGHT> {
     pub right: HelixFlowResult<RIGHT>,
 }
 
+impl Relationship for Contains<TaskList, Task> {
+    type Left = TaskList;
+    type Right = Task;
+}
+
 impl<LEFT, RIGHT> Try for Contains<LEFT, RIGHT>
 where
     Contains<LEFT, RIGHT>: Relationship,
@@ -127,11 +132,6 @@ where
             },
         })
     }
-}
-
-impl Relationship for Contains<TaskList, Task> {
-    type Left = TaskList;
-    type Right = Task;
 }
 
 impl<LEFT, RIGHT> Link for Contains<LEFT, RIGHT>

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -10,14 +10,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use uuid::{Uuid, uuid};
 
-/// Marker trait for our data items
-pub trait HelixFlowItem
-where
-    // required for Mismatch Error (which uses `Box<dyn HelixFlowItem>`)
-    Self: std::fmt::Debug + Send + Sync + 'static + Any,
-{
-    fn as_any(&self) -> &dyn Any;
-}
+use crate::HelixFlowItem;
 
 impl HelixFlowItem for Task {
     fn as_any(&self) -> &dyn Any {

--- a/helixflow-core/src/task.rs
+++ b/helixflow-core/src/task.rs
@@ -134,8 +134,13 @@ impl Relationship for Contains<TaskList, Task> {
     type Right = Task;
 }
 
-impl Link for Contains<TaskList, Task> {
-    fn create_linked_item<B: Relate<Contains<TaskList, Task>>>(
+impl<LEFT, RIGHT> Link for Contains<LEFT, RIGHT>
+where
+    Contains<LEFT, RIGHT>: Relationship,
+    LEFT: HelixFlowItem,
+    RIGHT: HelixFlowItem + Clone + PartialEq,
+{
+    fn create_linked_item<B: Relate<Contains<LEFT, RIGHT>>>(
         self,
         backend: &B,
     ) -> HelixFlowResult<()> {

--- a/helixflow/src/lib.rs
+++ b/helixflow/src/lib.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, rc::Rc};
 use log::debug;
 use slint::ComponentHandle;
 
-use helixflow_core::task::{CRUD, TaskList};
+use helixflow_core::{CRUD, task::TaskList};
 use helixflow_slint::{
     HelixFlow,
     task::{create_task, create_task_in_backlog, load_backlog},

--- a/helixflow/tests/slint_surreal.rs
+++ b/helixflow/tests/slint_surreal.rs
@@ -3,7 +3,10 @@ use std::rc::Rc;
 use slint::platform::PointerEventButton;
 use slint::{ComponentHandle, Global};
 
-use helixflow_core::task::{CRUD, Task, TaskList};
+use helixflow_core::{
+    CRUD,
+    task::{Task, TaskList},
+};
 use helixflow_slint::{
     CurrentTask, HelixFlow,
     task::{create_task, create_task_in_backlog, load_backlog},

--- a/ui/helixflow-slint/src/task.rs
+++ b/ui/helixflow-slint/src/task.rs
@@ -5,8 +5,9 @@ use uuid::Uuid;
 use slint::{ComponentHandle, VecModel};
 use slint::{Global, ModelRc, SharedString, ToSharedString};
 
-use helixflow_core::task::{
-    CRUD, Contains, HelixFlowError, HelixFlowResult, Link, Linkable, Relate, Store, Task, TaskList,
+use helixflow_core::{
+    HelixFlowError, HelixFlowResult,
+    task::{CRUD, Contains, Link, Linkable, Relate, Store, Task, TaskList},
 };
 
 use crate::{Backlog, CurrentTask, HelixFlow, SlintTask, SlintTaskList};

--- a/ui/helixflow-slint/src/task.rs
+++ b/ui/helixflow-slint/src/task.rs
@@ -6,8 +6,8 @@ use slint::{ComponentHandle, VecModel};
 use slint::{Global, ModelRc, SharedString, ToSharedString};
 
 use helixflow_core::{
-    HelixFlowError, HelixFlowResult,
-    task::{CRUD, Contains, Link, Linkable, Relate, Store, Task, TaskList},
+    CRUD, HelixFlowError, HelixFlowResult, Link, Linkable, Relate, Store,
+    task::{Contains, Task, TaskList},
 };
 
 use crate::{Backlog, CurrentTask, HelixFlow, SlintTask, SlintTaskList};

--- a/ui/helixflow-slint/tests/backlog.rs
+++ b/ui/helixflow-slint/tests/backlog.rs
@@ -4,7 +4,10 @@ use uuid::uuid;
 
 use slint::{ComponentHandle, ModelRc, VecModel};
 
-use helixflow_core::task::{CRUD, Linkable, TaskList, TestBackend};
+use helixflow_core::{
+    CRUD, Linkable,
+    task::{TaskList, TestBackend},
+};
 use helixflow_slint::{Backlog, SlintTask, task::load_backlog, test::*};
 
 #[test]


### PR DESCRIPTION
## Summary by Sourcery

Refactor helixflow-core by moving shared traits and error handling into lib.rs, simplifying task.rs, generalizing relationship and linking abstractions, and cleaning up backend tests and dependencies.

Enhancements:
- Centralize common traits (HelixFlowItem, CRUD, Store, Relationship, Link, Linkable, Relate), error enum, and result type into lib.rs
- Simplify task.rs by importing shared constructs instead of redefining traits and types
- Generalize linking logic with generic Link and Linkable implementations for any Relationship
- Restructure surrealdb backend tests to replace rstest_reuse with explicit BackendKind fixture setup and TempPath cleanup

Chores:
- Remove unused rstest_reuse dependency from Cargo.toml and other manifest cleanups